### PR TITLE
Run docker containers as non-root

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -50,6 +50,12 @@ do \
     keytool -import -file $file -alias $file -cacerts -storepass changeit -noprompt; \
 done
 
+RUN chmod 755 /opt/app && \
+    chmod 644 /opt/app/status-board-assembly.jar && \
+    chmod 755 /opt/app/entrypoint.sh
+
+USER 10001:10001
+
 EXPOSE $PORT
 WORKDIR /opt/app
 ENTRYPOINT ["./entrypoint.sh"]

--- a/UI.Dockerfile
+++ b/UI.Dockerfile
@@ -9,13 +9,16 @@
 
 ARG BASE_IMAGE=nginx
 
-
 FROM $BASE_IMAGE
 LABEL org.opencontainers.image.authors="ABSA"
 
 # Project should be build locally by running `npm run build`
 COPY ./ui/dist/ui/browser/ /usr/share/nginx/html
 COPY ./ui/conf/nginx.conf /etc/nginx/conf.d/default.conf
+
+RUN chmod -R 777 /var/cache/nginx /var/run
+
+USER nginx
 
 EXPOSE 4200
 


### PR DESCRIPTION
This pull request introduces improvements to the Dockerfiles for both the backend and frontend services to enhance security and ensure proper file permissions. The main changes involve setting appropriate permissions for application files and directories, and running containers as non-root users.

**Dockerfile changes for backend (`Dockerfile`):**

* Set permissions: Changed permissions for `/opt/app` (755), `status-board-assembly.jar` (644), and `entrypoint.sh` (755) to ensure correct access rights.
* Non-root user: Configured the container to run as user `10001:10001` instead of root, improving security.

**Dockerfile changes for frontend (`UI.Dockerfile`):**

* Set permissions: Recursively set permissions (777) for `/var/cache/nginx` and `/var/run` to allow the nginx process to write to these directories.
* Non-root user: Configured the container to run as the `nginx` user, rather than root, for better security

Release notes:
- Changes docker images to run application as non-root

Closes: #25 