### PR TITLE
feat(sec): Adopting AquaSec Night scan solution

### DIFF
--- a/.github/workflows/aquasec-night-scan.yml
+++ b/.github/workflows/aquasec-night-scan.yml
@@ -1,0 +1,36 @@
+name: AquaSec Night Scan
+
+on:
+  schedule:
+    - cron: '45 2 * * *'
+  workflow_dispatch:
+    inputs:
+      dry-run:
+        description: Enable Dry Run mode
+        required: false
+        type: boolean
+        default: false
+
+concurrency:
+  group: aquasec-night-scan-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  actions: read
+  issues: write
+
+jobs:
+  aquasec-night-scan:
+    uses: AbsaOSS/organizational-workflows/.github/workflows/aquasec-scan.yml@3b6a6b035bc2ddd0b0f2a8f8854df19314474312
+    with:
+      dry-run: ${{ inputs.dry-run || false }}
+      min-severity: 'high'
+      project-number: 193
+      project-org: 'absa-group'
+    secrets:
+      AQUA_KEY: ${{ secrets.AQUA_KEY }}
+      AQUA_SECRET: ${{ secrets.AQUA_SECRET }}
+      AQUA_GROUP_ID: ${{ secrets.AQUA_GROUP_ID }}
+      AQUA_REPOSITORY_ID: ${{ secrets.AQUA_REPOSITORY_ID }}
+      TEAMS_WEBHOOK_URL: ${{ secrets.TEAMS_WEBHOOK_URL }}

--- a/.github/workflows/release_draft.yml
+++ b/.github/workflows/release_draft.yml
@@ -69,6 +69,9 @@ jobs:
           print-empty-chapters: false
           row-format-issue: '{type}: {number} _{title}_ by {developers} in {pull-requests}'
           row-format-pr: '{number} _{title}_ by {developers}'
+          service-chapter-exclude: |
+            Closed Issues without Pull Request ⚠️:
+              - [scope:security, type:tech-debt]
 
       - name: Create and push tag
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3


### PR DESCRIPTION
<!-- What problem does it solve or what feature does it add? -->
## Overview
This pull request introduces a new scheduled GitHub Actions workflow to automate nightly AquaSec security scans. The workflow is configurable, supports manual triggering with a dry-run option, and is integrated with organizational secrets and permissions.

<!-- Summarize the key changes in this PR. -->
## Release Notes
- Adding the AquaSec Nigh Scan workflow, that generates security Aqua findings as GH issues. Severity >= high.
- Creation of following repo labels: scope:security, type:tech-debt, sec:suppression, sec:false-positive.
- Adding the AQUA_GROUP_ID and AQUA_REPOSITORY_ID secrets to repo action secrets.

<!-- Add attached issue that this PR solves. -->
## Related
Closes #43 