### PR TITLE
Update MS Teams webhook URL for integration tests

### DIFF
--- a/src/main/scala/za/co/absa/statusboard/providers/BlazeHttpClientProvider.scala
+++ b/src/main/scala/za/co/absa/statusboard/providers/BlazeHttpClientProvider.scala
@@ -36,8 +36,8 @@ class BlazeHttpClientProvider(httpClient: Client[Task]) extends HttpClientProvid
     requestPhase1 <- maybeRequestPayload match {
       case Some(payload) => ZIO.attempt {
         requestPhase0
-          .withHeaders(Header.Raw(CIString(ContentType), "application/json"))
           .withEntity(payload)
+          .withHeaders(Header.Raw(CIString(ContentType), "application/json"))
       }
       case None => ZIO.succeed(requestPhase0)
     }

--- a/src/test/resources/reference.conf
+++ b/src/test/resources/reference.conf
@@ -13,7 +13,7 @@
       endpointOverride = "http://localhost:8000", # uses default DynamoDB endpoint when not present
     }
     msTeams {
-      webhookUrl = "https://absacorp.webhook.office.com/webhookb2/cdab3b4b-3a63-4301-bc10-223fe664d14c@5be1f46d-495f-465b-9507-996e8c8cdcb6/IncomingWebhook/dfdef7e98b874fffa4bd02ccda50ca3c/5626d7ac-4195-4371-84b0-2d2dd6fda4a9/V2ybjXO7jSkHYGP6g0HZyX2sK-_U6dNQ3bJWijbj4EbhE1"
+      webhookUrl = "https://default5be1f46d495f465b9507996e8c8cdc.b6.environment.api.powerplatform.com:443/powerautomate/automations/direct/workflows/1aff98fdd3d94c61af3a6cb6ce2c99e4/triggers/manual/paths/invoke?api-version=1&sp=%2Ftriggers%2Fmanual%2Frun&sv=1.0&sig=2j1CXTAzeoEWh9cilohzs07Q2GRUKg7iRVdcoGEMTEM"
     }
     email {
       smtpHost = "smtp.absa.co.za"


### PR DESCRIPTION
This pull request introduces a configuration update and a minor code refactor to improve clarity and maintainability. The most important changes are:

**Configuration Updates:**

* Updated the `msTeams.webhookUrl` in `reference.conf` to point to a new Power Automate endpoint, replacing the previous Office.com webhook URL.

**Code Refactor:**

* In `BlazeHttpClientProvider.scala`, reordered the addition of the `Content-Type: application/json` header to occur after setting the request entity, ensuring clarity in the request-building process.This pull request updates the configuration for Microsoft Teams integration in the `reference.conf` file. The main change is the replacement of the `msTeams.webhookUrl` with a new default Power Platform automation endpoint.

Configuration update:

* Updated the `msTeams.webhookUrl` value to point to a new Power Platform automation endpoint, replacing the previous Office.com webhook URL.<!-- What problem does it solve or what feature does it add? -->
## Overview

<!-- Summarize the key changes for release notes. -->
## Release Notes
- Updated the MS Teams webhook integration test
- Fixed a bug in the HTTP client provider causing ignoring HTTP header configuration

<!-- Add attached issue that this PR solves. -->
## Related
Closes #45
